### PR TITLE
Death state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: logan  <logan@42.us.org>                   +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2018/03/13 10:03:24 by logan             #+#    #+#              #
-#    Updated: 2018/04/19 14:05:41 by lkaser           ###   ########.fr        #
+#    Updated: 2018/05/08 18:59:19 by twalton          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -28,6 +28,7 @@ generate_level \
 Engine \
 MenuState \
 TestState \
+DeathState \
 ParticleExplosion \
 Text \
 Cells \
@@ -52,7 +53,7 @@ $(shell pkg-config --cflags glfw3 glm) \
 LDFLAGS = -framework OpenGl \
 $(shell pkg-config --libs glfw3 glm) \
 -L lib/lodepng -llodepng \
--fsanitize=undefined -fsanitize=address
+-g -fsanitize=undefined -fsanitize=address
 
 all: $(OBJ_DIR) $(NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,12 @@ $(shell pkg-config --cflags glfw3 glm) \
 -I lib/entt/src \
 -I lib/lodepng \
 -g -O3 -march=native \
-# -fsanitize=undefined -fsanitized=address
+-fsanitize=undefined -fsanitize=address
 
 LDFLAGS = -framework OpenGl \
 $(shell pkg-config --libs glfw3 glm) \
 -L lib/lodepng -llodepng \
-# -fsanitize=undefined -fsanitized=address
+-fsanitize=undefined -fsanitize=address
 
 all: $(OBJ_DIR) $(NAME)
 

--- a/src/DeathState.cpp
+++ b/src/DeathState.cpp
@@ -1,0 +1,15 @@
+#include "DeathState.hpp"
+
+DeathState::DeathState(Engine& engine) :
+	_engine(engine), _window(engine.window)
+{
+	
+}
+
+DeathState::~DeathState(void)
+{
+}
+
+void	DeathState::Update(double dt)
+{
+}

--- a/src/DeathState.cpp
+++ b/src/DeathState.cpp
@@ -1,9 +1,15 @@
 #include "DeathState.hpp"
 
 DeathState::DeathState(Engine& engine) :
-	_engine(engine), _window(engine.window)
+_engine(engine), _window(engine.window)
 {
-	
+	auto entity = _registry.create();
+
+	_registry.assign<c::Button>(entity,
+				    callbacks::change_state(StateType::Level1, _engine));
+
+	_registry.assign<c::Image>(entity,
+				  "assets/textures/metal_sheet.png");
 }
 
 DeathState::~DeathState(void)
@@ -12,4 +18,6 @@ DeathState::~DeathState(void)
 
 void	DeathState::Update(double dt)
 {
+	systems::Buttons(_registry, _window);
+	systems::Images(_registry, _imageCache, _window);
 }

--- a/src/DeathState.hpp
+++ b/src/DeathState.hpp
@@ -11,6 +11,7 @@ class	DeathState : public IState
 	Engine& _engine;
 	Window& _window;
 	entt::DefaultRegistry _registry;
+	entt::ResourceCache<Sprite2D> _imageCache;
 
 public:
 	DeathState(Engine& engine);

--- a/src/DeathState.hpp
+++ b/src/DeathState.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "bomberman.hpp"
+#include "Engine.hpp"
+#include "IState.hpp"
+#include "systems.hpp"
+#include "components.hpp"
+
+class	DeathState : public IState
+{
+	Engine& _engine;
+	Window& _window;
+	entt::DefaultRegistry _registry;
+
+public:
+	DeathState(Engine& engine);
+	~DeathState(void);
+	void	Update(double dt);
+};

--- a/src/IState.hpp
+++ b/src/IState.hpp
@@ -11,3 +11,10 @@ public:
 	virtual ~IState(void) {};
 	virtual void Update(double dt) = 0;
 };
+
+enum class StateType
+{
+	Menu,
+	Level1,
+	DeathScreen
+};

--- a/src/MenuState.cpp
+++ b/src/MenuState.cpp
@@ -12,14 +12,21 @@ _engine(e), _window(e.window)
 {
 	auto entity = _registry.create();	
 
-	auto nextstate = [this](){
+	auto nextstate = [this](entt::DefaultRegistry& r, uint32_t e)
+	{
 		_engine.PushState(new TestState(_engine));
 	};
 	
 	_registry.assign<c::Button>(entity,
-		"assets/textures/metal_sheet.png", "assets/textures/stone_floor.png",
-		nextstate, glm::vec2(-0.1, -0.1), glm::vec2(0.1, 0.1), 0.1f);
+				    nextstate,
+				    glm::vec2(-0.1, -0.1),
+				    glm::vec2(0.1, 0.1));
 
+	_registry.assign<c::Image>(entity,
+				   "assets/textures/metal_sheet.png",
+				   glm::vec2(-0.1, -0.1),
+				   glm::vec2(0.1, 0.1));
+	
 	glClearColor(0.2, 0.25, 0.29, 1.0);
 }
 
@@ -27,7 +34,6 @@ MenuState::~MenuState(void) {}
 
 void MenuState::Update(double dt)
 {
-	Text t("abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRZTUVWXYZ 1234567890");
-	systems::Buttons(_registry, _imageCache, _window, dt);
-	t.Render(_window.GetAspect());
+	systems::Buttons(_registry, _window);
+	systems::Images(_registry, _imageCache, _window);
 }

--- a/src/TestState.cpp
+++ b/src/TestState.cpp
@@ -9,8 +9,6 @@ _engine(e), _window(e.window)
 	_camera.Rotate(glm::vec3(0, 0, 1), 90);
 	_camera.Rotate(glm::vec3(0, 1, 0), 64);
 
-	Effects::explosion = new ParticleExplosion(1.0f);
-
 // create AI test
 
 	auto enemy = _registry.create();
@@ -48,7 +46,6 @@ _engine(e), _window(e.window)
 
 TestState::~TestState(void)
 {
-	Effects::CleanUp();
 }
 
 void TestState::Update(double dt)

--- a/src/TestState.cpp
+++ b/src/TestState.cpp
@@ -41,7 +41,7 @@ _engine(e), _window(e.window)
 	_registry.assign<c::Vulnerable>(enemy_r, callbacks::explode(3) + callbacks::destroy(), 11);
 
 
-	generate_level(_registry, 16, 16);
+	generate_level(_registry, 16, 16, _engine);
 
 	glClearColor(0.2, 0.25, 0.29, 1.0);
 }

--- a/src/TestState.cpp
+++ b/src/TestState.cpp
@@ -54,7 +54,8 @@ void TestState::Update(double dt)
 	
 	systems::RenderModels(_registry, _modelCache, _window, _camera, dt);
 	systems::TimedEffect(_registry, dt);
-	systems::Buttons(_registry, _imageCache, _window, dt);
+	systems::Buttons(_registry, _window);
+	systems::Images(_registry, _imageCache, _window);
 	systems::Player(_registry, _window, _engine.keyBind, _cellQuery, _camera, dt);
 	systems::Velocity(_registry, _cellQuery, dt);
 	systems::RenderParticles(_registry, _camera);

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -81,8 +81,7 @@ callbacks::callbackType	callbacks::change_state(StateType st, Engine& engine)
 	case StateType::DeathScreen:
 		return [&engine](entt::DefaultRegistry& r, uint32_t e)
 		{
-			//engine.ChangeState(new DeathState(engine));
-			engine.ChangeState(new TestState(engine));
+			engine.ChangeState(new DeathState(engine));
 		};
 	}
 }

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -69,6 +69,24 @@ callbacks::callbackType	callbacks::destroy(void)
 	return f;
 }
 
+callbacks::callbackType	callbacks::change_state(StateType st, Engine& engine)
+{
+	switch (st)
+	{
+	case StateType::Level1:
+		return [&engine](entt::DefaultRegistry& r, uint32_t e)
+		{
+			engine.ChangeState(new TestState(engine));
+		};
+	case StateType::DeathScreen:
+		return [&engine](entt::DefaultRegistry& r, uint32_t e)
+		{
+			//engine.ChangeState(new DeathState(engine));
+			engine.ChangeState(new TestState(engine));
+		};
+	}
+}
+
 callbacks::callbackType	operator + (callbacks::callbackType a, callbacks::callbackType b)
 {
 	auto f = [a, b](entt::DefaultRegistry& r, uint32_t e)

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -73,6 +73,11 @@ callbacks::callbackType	callbacks::change_state(StateType st, Engine& engine)
 {
 	switch (st)
 	{
+	case StateType::Menu:
+		return [&engine](entt::DefaultRegistry& r, uint32_t e)
+		{
+			engine.ChangeState(new TestState(engine));
+		};
 	case StateType::Level1:
 		return [&engine](entt::DefaultRegistry& r, uint32_t e)
 		{

--- a/src/callbacks.hpp
+++ b/src/callbacks.hpp
@@ -4,20 +4,27 @@
 #include "components.hpp"
 #include "Effects.hpp"
 #include "powerups.hpp"
+#include "Engine.hpp"
+
+#include "TestState.hpp"
+//#include "DeathState.hpp"
 
 namespace callbacks
 {
 	typedef std::function<void(entt::DefaultRegistry&, uint32_t)> callbackType;
 
 	callbackType	explode(int power);
-
 	callbackType	ignite(void);
-
 	callbackType	bomb(int power);
-
 	callbackType	powerup(float spawnChance);
-	
 	callbackType	destroy(void);
+
+	enum class StateType
+	{
+		Level1,
+		DeathScreen
+	};
+	callbackType	change_state(StateType st, Engine& engine);
 };
 
 callbacks::callbackType	operator + (callbacks::callbackType, callbacks::callbackType);

--- a/src/callbacks.hpp
+++ b/src/callbacks.hpp
@@ -19,11 +19,6 @@ namespace callbacks
 	callbackType	powerup(float spawnChance);
 	callbackType	destroy(void);
 
-	enum class StateType
-	{
-		Level1,
-		DeathScreen
-	};
 	callbackType	change_state(StateType st, Engine& engine);
 };
 

--- a/src/callbacks.hpp
+++ b/src/callbacks.hpp
@@ -7,7 +7,7 @@
 #include "Engine.hpp"
 
 #include "TestState.hpp"
-//#include "DeathState.hpp"
+#include "DeathState.hpp"
 
 namespace callbacks
 {

--- a/src/components.hpp
+++ b/src/components.hpp
@@ -36,21 +36,26 @@ namespace components
 
 	struct Button
 	{
-		std::string imageBefore;
-		std::string imageAfter;
-		std::function<void()> f;
-		glm::vec2 botLeft;
-		glm::vec2 topRight;
-		float cooldown = 0;
-		float cooldownTimer = 0;
+                std::function<void(entt::DefaultRegistry&, uint32_t)> onClick;
+		glm::vec2 botLeft = glm::vec2(-1, -1);
+		glm::vec2 topRight = glm::vec2(1, 1);
 	};
 
+	struct Image
+	{		
+		std::string name;
+		glm::vec2 botLeft = glm::vec2(-1, -1);
+		glm::vec2 topRight = glm::vec2(1, 1);
+	};
+	
 	struct Player
 	{
 		double speed;
 		double bombCooldown;
 		int bombPower = 1;
 		double bombCooldownTimer = 0;
+
+		~Player(){std::cout << "test" << std::endl;}
 	};
 
 	struct Velocity

--- a/src/components.hpp
+++ b/src/components.hpp
@@ -54,8 +54,6 @@ namespace components
 		double bombCooldown;
 		int bombPower = 1;
 		double bombCooldownTimer = 0;
-
-		~Player(){std::cout << "test" << std::endl;}
 	};
 
 	struct Velocity

--- a/src/generate_level.cpp
+++ b/src/generate_level.cpp
@@ -26,7 +26,7 @@ static void spawn_player(entt::DefaultRegistry &r, int x, int y, Engine& engine)
 	r.assign<c::Velocity>(player);
 	r.assign<c::Collide>(player, 4);
 	r.assign<c::Vulnerable>(player,
-				callbacks::change_state(callbacks::StateType::Level1, engine) +
+				callbacks::change_state(callbacks::StateType::DeathScreen, engine) +
 				callbacks::destroy());
 }
 

--- a/src/generate_level.cpp
+++ b/src/generate_level.cpp
@@ -26,7 +26,7 @@ static void spawn_player(entt::DefaultRegistry &r, int x, int y, Engine& engine)
 	r.assign<c::Velocity>(player);
 	r.assign<c::Collide>(player, 4);
 	r.assign<c::Vulnerable>(player,
-				callbacks::change_state(callbacks::StateType::DeathScreen, engine) +
+				callbacks::change_state(StateType::DeathScreen, engine) +
 				callbacks::destroy());
 }
 

--- a/src/generate_level.cpp
+++ b/src/generate_level.cpp
@@ -16,7 +16,7 @@ static glm::mat4 random_direction()
 	return dirs[pick_dir(rng)];
 }
 
-static void spawn_player(entt::DefaultRegistry &r, int x, int y)
+static void spawn_player(entt::DefaultRegistry &r, int x, int y, Engine& engine)
 {
 	auto player = r.create();
 	
@@ -25,7 +25,9 @@ static void spawn_player(entt::DefaultRegistry &r, int x, int y)
 	r.assign<c::Position>(player, glm::vec3(x, y, 0));
 	r.assign<c::Velocity>(player);
 	r.assign<c::Collide>(player, 4);
-	r.assign<c::Vulnerable>(player, callbacks::destroy());
+	r.assign<c::Vulnerable>(player,
+				callbacks::change_state(callbacks::StateType::Level1, engine) +
+				callbacks::destroy());
 }
 
 static void spawn_wall(entt::DefaultRegistry &r, std::string type, int x, int y)
@@ -73,7 +75,7 @@ void spawn_static_lights(entt::DefaultRegistry &r)
 	r.assign<c::Lighting>(light, glm::vec3(1.3, 1.3, 1.3), 10000.0f);
 }
 
-void	generate_level(entt::DefaultRegistry &r, int w, int h)
+void	generate_level(entt::DefaultRegistry &r, int w, int h, Engine& engine)
 {
 	w /= 2;
 	h /= 2;
@@ -109,6 +111,6 @@ void	generate_level(entt::DefaultRegistry &r, int w, int h)
 			spawn_floor(r, x, y);
 		}
 	}
-	spawn_player(r, -w + 1, -h + 1);
+	spawn_player(r, -w + 1, -h + 1, engine);
 	spawn_static_lights(r);
 }

--- a/src/generate_level.hpp
+++ b/src/generate_level.hpp
@@ -5,7 +5,8 @@
 #include "ParticleExplosion.hpp"
 #include "Effects.hpp"
 #include "callbacks.hpp"
+#include "Engine.hpp"
 
 namespace c = components;
 
-void	generate_level(entt::DefaultRegistry &r, int w, int h);
+void	generate_level(entt::DefaultRegistry &r, int w, int h, Engine& engine);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,22 @@
 #include "bomberman.hpp"
 #include "MenuState.hpp"
+#include "ParticleExplosion.hpp"
+#include "Effects.hpp"
 
 int	main(void)
 {
 	Window window(1024, 1024, "bomberman");
 	Engine engine(window);
+
+	Effects::explosion = new ParticleExplosion(1.0f);
+	
 	engine.PushState(new MenuState(engine));
 	while (engine.isRunning)
 	{
 		engine.Run();
 	}
+
+	Effects::CleanUp();
+	
 	return 0;
 }

--- a/src/systems.cpp
+++ b/src/systems.cpp
@@ -115,7 +115,7 @@ struct	ImageLoader : entt::ResourceLoader<ImageLoader, Sprite2D>
 
 void	Images(entt::DefaultRegistry& r, entt::ResourceCache<Sprite2D>& cache, Window& window)
 {
-	auto view = registry.view<c::Image>();
+	auto view = r.view<c::Image>();
 
 	for (auto entity : view)
 	{
@@ -154,22 +154,22 @@ void	Player(entt::DefaultRegistry& r, Window& window, Engine::KeyBind bind,
 	if (window.Key(bind.up))
 	{
 		transform = FACE_UP;
-		v.y += player.speed * dt;
+		v.y += player.speed;
 	}
 	if (window.Key(bind.down))
 	{
 		transform = FACE_DOWN;
-		v.y -= player.speed * dt;
+		v.y -= player.speed;
 	}
 	if (window.Key(bind.left))
 	{
 		transform = FACE_LEFT;
-		v.x -= player.speed * dt;
+		v.x -= player.speed;
 	}
 	if (window.Key(bind.right))
 	{
 		transform = FACE_RIGHT;
-		v.x += player.speed * dt;
+		v.x += player.speed;
 	}
 	if (window.Key(bind.bomb))
 	{
@@ -238,6 +238,10 @@ static void    checkCollisions(glm::vec3 &pos, glm::vec3 &v, Cells &cells, doubl
 
 void	Velocity(entt::DefaultRegistry& registry, Cells &cells, double dt)
 {
+
+	if (dt > 0.2) // to stop lag spikes breaking physics
+		dt = 0.2;
+	
 	auto coll = registry.view<c::Velocity, c::Position, c::Collide>();
 
 	for (auto entity : coll)
@@ -246,6 +250,7 @@ void	Velocity(entt::DefaultRegistry& registry, Cells &cells, double dt)
 		glm::vec3 &v = coll.get<c::Velocity>(entity).v;
 		int height = coll.get<c::Collide>(entity).height;
 
+		v *= dt;
 		checkCollisions(pos, v, cells, dt, height);
 	}
 	
@@ -386,13 +391,13 @@ void	AI(entt::DefaultRegistry &registry, Window &window, double dt)
 		//else
 		//{
 			if (ai.dir == c::Direction::UP)
-				v.y = ai.speed * dt;
+				v.y = ai.speed;
 			else if (ai.dir == c::Direction::RIGHT)
-				v.x = ai.speed * dt;
+				v.x = ai.speed;
 			else if (ai.dir == c::Direction::DOWN)
-				v.y = -ai.speed * dt;
+				v.y = -ai.speed;
 			else if (ai.dir == c::Direction::LEFT)
-				v.x = -ai.speed * dt;
+				v.x = -ai.speed;
 		//}
 		ai.moveCooldownTimer -= dt;
 		move.v = v;

--- a/src/systems.cpp
+++ b/src/systems.cpp
@@ -64,7 +64,7 @@ void	RenderModels(entt::DefaultRegistry &registry, entt::ResourceCache<Model>& c
 }
 
 //! TimedEffect
-
+	
 void	TimedEffect(entt::DefaultRegistry &registry, double dt)
 {
 	auto view = registry.view<c::TimedEffect>();
@@ -82,6 +82,29 @@ void	TimedEffect(entt::DefaultRegistry &registry, double dt)
 
 //! Buttons
 
+void	Buttons(entt::DefaultRegistry &r, Window& window)
+{
+	auto view = r.view<c::Button>();
+
+	for (auto entity : view)
+	{
+		auto& button = view.get(entity);
+
+		if (window.MouseClick(0))
+		{
+			glm::vec2 pos = window.MousePos();
+
+			if (pos.x >= button.botLeft.x && pos.x <= button.topRight.x &&
+			    pos.y >= button.botLeft.y && pos.y <= button.topRight.y)
+			{
+				button.onClick(r, entity);
+			}
+		}
+	}
+}
+
+//! Images
+	
 struct	ImageLoader : entt::ResourceLoader<ImageLoader, Sprite2D>
 {
 	std::shared_ptr<Sprite2D>  load(const std::string imagePath) const
@@ -90,50 +113,24 @@ struct	ImageLoader : entt::ResourceLoader<ImageLoader, Sprite2D>
 	}
 };
 
-void	Buttons(entt::DefaultRegistry &registry,
-		entt::ResourceCache<Sprite2D> &cache, Window &window, double dt)
+void	Images(entt::DefaultRegistry& r, entt::ResourceCache<Sprite2D>& cache, Window& window)
 {
-	auto view = registry.view<c::Button>();
+	auto view = registry.view<c::Image>();
 
 	for (auto entity : view)
 	{
-		auto &button = view.get(entity);
+		auto &image = view.get(entity);
 
-		// render logic
-		std::string imagePath;
-
-		if (button.cooldownTimer <= 0)
-			imagePath = button.imageBefore;
-		else
-			imagePath = button.imageAfter;
-
-		window.SetRenderMask((button.botLeft.x + 1) / 2,
-				     (button.botLeft.y + 1) / 2,
-				     (button.topRight.x - button.botLeft.x) / 2,
-				     (button.topRight.y - button.botLeft.y) / 2);
-
-		cache.load<ImageLoader>(entt::HashedString(imagePath.c_str()), imagePath);
-		const Sprite2D &im = cache.handle(entt::HashedString(imagePath.c_str())).get();
+		window.SetRenderMask((image.botLeft.x + 1) / 2,
+				     (image.botLeft.y + 1) / 2,
+				     (image.topRight.x - image.botLeft.x) / 2,
+				     (image.topRight.y - image.botLeft.y) / 2);
+		
+		cache.load<ImageLoader>(entt::HashedString(image.name.c_str()), image.name);
+		const Sprite2D &im = cache.handle(entt::HashedString(image.name.c_str())).get();
 		const_cast<Sprite2D&>(im).Render();
 
 		window.RemoveRenderMask();
-
-		// button logic
-		button.cooldownTimer -= dt;
-		if (window.MouseClick(0))
-		{
-			glm::vec2 pos = window.MousePos();
-
-			if (pos.x >= button.botLeft.x && pos.x <= button.topRight.x &&
-			    pos.y >= button.botLeft.y && pos.y <= button.topRight.y)
-			{
-				if (button.cooldownTimer <= 0)
-				{
-					button.f();
-					button.cooldownTimer = button.cooldown;
-				}
-			}
-		}
 	}
 }
 
@@ -151,8 +148,6 @@ void	Player(entt::DefaultRegistry& r, Window& window, Engine::KeyBind bind,
 	auto &move = r.get<c::Velocity>(entity);
 	glm::vec3 &pos = r.get<c::Position>(entity).pos;
 	glm::mat4 &transform = r.get<c::Model>(entity).transform;
-
-	cells.Powerup(pos.x, pos.y)(r, entity);
 
 	glm::vec3 v(0, 0, 0);
 		
@@ -188,6 +183,7 @@ void	Player(entt::DefaultRegistry& r, Window& window, Engine::KeyBind bind,
 	auto target = glm::vec3(pos.x, pos.y - 10, 20);
 	cam.Move((target - cam.GetPosition()) * dt);
 	move.v = v;
+	cells.Powerup(pos.x, pos.y)(r, entity);
 }
 
 //! Lighting
@@ -207,22 +203,22 @@ void	Lighting(entt::DefaultRegistry& r, double dt)
 
 static void    checkCollisions(glm::vec3 &pos, glm::vec3 &v, Cells &cells, double dt, int height)
 {
-	if (v.y > 0 && height <= cells.Collision(pos.x, pos.y + 1))
+	if (v.y > 0 && height < cells.Collision(pos.x, pos.y + 1))
 	{
 		if (pos.y > roundf(pos.y))
 			v.y = 0;
 	}
-	if (v.y < 0 && height <= cells.Collision(pos.x, pos.y - 1))
+	if (v.y < 0 && height < cells.Collision(pos.x, pos.y - 1))
 	{
 		if (pos.y < roundf(pos.y))
 			v.y = 0;
 	}
-	if (v.x > 0 && height <= cells.Collision(pos.x + 1, pos.y))
+	if (v.x > 0 && height < cells.Collision(pos.x + 1, pos.y))
 	{
 		if (pos.x > roundf(pos.x))
 			v.x = 0;
 	}
-	if (v.x < 0 && height <= cells.Collision(pos.x - 1, pos.y))
+	if (v.x < 0 && height < cells.Collision(pos.x - 1, pos.y))
 	{
 		if (pos.x < roundf(pos.x))
 			v.x = 0;

--- a/src/systems.hpp
+++ b/src/systems.hpp
@@ -32,8 +32,11 @@ namespace systems
 	void	TimedEffect(entt::DefaultRegistry&, double dt);
 
 	//! requires: Button
-	void	Buttons(entt::DefaultRegistry&, entt::ResourceCache<Sprite2D>&, Window&, double dt);
+	void	Buttons(entt::DefaultRegistry&, Window&);
 
+	//! requires: Image
+	void	Images(entt::DefaultRegistry&, entt::ResourceCache<Sprite2D>&, Window&);
+	
 	//! requires: Lighting; Applies falloff delta
 	void	Lighting(entt::DefaultRegistry&, double dt);
 


### PR DESCRIPTION
reworked the button component to become a mouse press event + image component.

Added in a state change callback that takes a state enum (stored inside IState), may potentially add a state push and state pop callback if we need.

Fixed lag spikes from breaking collision

Added a basic death state that demonstrates the state change callback