### PR TITLE
stopped lights overflowing when more than 100 lights present in scene

### DIFF
--- a/src/ObjFile.cpp
+++ b/src/ObjFile.cpp
@@ -127,6 +127,7 @@ void	ObjFile::Render(void)
 	_program->Use();
 
 	int size = Light::positions.size();
+	size = std::min(size, 99);
 	if (size)
 	{
 		glUniform3fv(_lightPosID,


### PR DESCRIPTION
still is 'random' what lights will be displayed when over 100 lights should be present in the scene but at least it doesnt overflow the buffer